### PR TITLE
Hotfix/0.1.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,9 @@
 # CHANGES
 
-## 0.1.1
+## 0.1.2
 
 * cleaned header of `get_tmp_fpkm.py`; It now produce compressed output by default, and has a `--no-compression` option to disable it.
+* consistent version number across scripts
 
 ## 0.1.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## 0.1.1
 
+* cleaned header of `get_tmp_fpkm.py`; It now produce compressed output by default, and has a `--no-compression` option to disable it.
+
+## 0.1.1
+
 * `gtftools.py` now uses tempfile for intermidiate output, and tells GTF formate using the first line after headers in a GTF file.
 * `get_tmp_fpkm.py` now has an option to specify output folder
 * `merge_samples.py` tells number of lines in header to ignore on the fly

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 LABEL maintainer="cgphelp@sanger.ac.uk" \
       uk.ac.sanger.cgp="Cancer, Ageing and Somatic Mutation, Wellcome Trust Sanger Institute" \
-      version="0.1.1" \
+      version="0.1.2" \
       description="cgp-convert-counts container"
 
 RUN apt-get -yq update

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ This project contain tools for converting RNAseq count data.
 
 ## Contained tools
 
-* ### gtfools.py
+* ### gtftools.py
 
-    The script is based on [GTFtools](http://www.genemine.org/gtftools.php) and can be used to calculate gene length from GTF files. If you use this script please cite:
+    The script is based on [GTFtools](http://www.genemine.org/gtftools.php)(Version: 0.6.5) and can be used to calculate gene length from GTF files. If you use this script please cite:
     
     Hong-Dong Li, GTFtools: a Python package for analyzing various modes of gene models, bioRxiv, 263517, doi: https://doi.org/10.1101/263517
 
-    Please refer to `gtfools.py -h` for its usage.
+    Please refer to `gtftools.py -h` for its usage.
 
 * ### get_tpm_fpkm.py
 

--- a/README.md
+++ b/README.md
@@ -12,24 +12,73 @@ This project contain tools for converting RNAseq count data.
 
     Please refer to `gtfools.py -h` for its usage.
 
-    Below is an example output:
-
-    ```bash
-    #ensid	gene	biotype	chr	mean median longest_isoform	merged
-    #ENSG00000255274	TMPRSS4-AS1	antisense	11	313	304	382	453
-    ```
-
 * ### get_tpm_fpkm.py
 
     The script calculates FPKM from raw HT-Seq counts
 
     Please refer to `get_tpm_fpkm.py -h` for its usage.
 
+    Below is an example output:
+
+    ```bash
+    $ gunzip -c PR13323c.count_count_fpkm_tpm.tsv.gz | head
+    ##count_file=/home/yaobo/Downloads/PR13323c.count.gz
+    ##gene_len=/home/yaobo/Downloads/ensembl.gene_length.tsv
+    ##minimum_read_count=0
+    ##gene_length_column=longest_isoform
+    ##transcript_biotype=['protein_coding']
+    ##Upper_Quartile_Val=3412
+    #ensid  gene    biotype chr     longest_isoform count   unfiltered_count        fpkm    fpkm_uq tpm
+    ENSG00000000003 TSPAN6  protein_coding  X       3796    6748    6748    18.24   521002.55       43.18
+    ENSG00000000005 TNMD    protein_coding  X       1339    0       0       0.0     0.0     0.0
+    ENSG00000000419 DPM1    protein_coding  20      1161    4022    4022    35.54   1015315.05      84.16
+    ```
+
 * ### merge_samples.py
 
     The script merges single sample results of *get_tpm_fpkm.py* into one file.
 
     Please refer to `merge_samples.py -h` for its usage.
+
+        Below is an example output:
+
+    ```bash
+    $ head -n 5 merged_*
+    ==> merged_count.tsv <==
+    ensid   gene    biotype chr     longest_isoform test2_count_fpkm_tpm    test_count_fpkm_tpm
+    ENSG00000177757 FAM87B  lincRNA 1       1944    2       6
+    ENSG00000185097 OR4F16  protein_coding  1       995     0       0
+    ENSG00000186092 OR4F5   protein_coding  1       918     0       0
+    ENSG00000187583 PLEKHN1 protein_coding  1       2455    96      213
+
+    ==> merged_fpkm.tsv <==
+    ensid   gene    biotype chr     longest_isoform test2_count_fpkm_tpm    test_count_fpkm_tpm
+    ENSG00000177757 FAM87B  lincRNA 1       1944    44.21   82.3
+    ENSG00000185097 OR4F16  protein_coding  1       995     0.0     0.0
+    ENSG00000186092 OR4F5   protein_coding  1       918     0.0     0.0
+    ENSG00000187583 PLEKHN1 protein_coding  1       2455    1680.37 2313.4
+
+    ==> merged_fpkm_uq.tsv <==
+    ensid   gene    biotype chr     longest_isoform test2_count_fpkm_tpm    test_count_fpkm_tpm
+    ENSG00000177757 FAM87B  lincRNA 1       1944    10716.74        14490.23
+    ENSG00000185097 OR4F16  protein_coding  1       995     0.0     0.0
+    ENSG00000186092 OR4F5   protein_coding  1       918     0.0     0.0
+    ENSG00000187583 PLEKHN1 protein_coding  1       2455    407331.98       407331.98
+
+    ==> merged_tpm.tsv <==
+    ensid   gene    biotype chr     longest_isoform test2_count_fpkm_tpm    test_count_fpkm_tpm
+    ENSG00000177757 FAM87B  lincRNA 1       1944    38.82   63.87
+    ENSG00000185097 OR4F16  protein_coding  1       995     0.0     0.0
+    ENSG00000186092 OR4F5   protein_coding  1       918     0.0     0.0
+    ENSG00000187583 PLEKHN1 protein_coding  1       2455    1475.67 1795.54
+
+    ==> merged_unfiltered_count.tsv <==
+    ensid   gene    biotype chr     longest_isoform test2_count_fpkm_tpm    test_count_fpkm_tpm
+    ENSG00000177757 FAM87B  lincRNA 1       1944    2       6
+    ENSG00000185097 OR4F16  protein_coding  1       995     0       0
+    ENSG00000186092 OR4F5   protein_coding  1       918     0       0
+    ENSG00000187583 PLEKHN1 protein_coding  1       2455    96      213
+    ```
 
 ## LICENSE
 

--- a/scripts/get_tpm_fpkm.py
+++ b/scripts/get_tpm_fpkm.py
@@ -6,7 +6,7 @@ import argparse
 import pandas as pd
 import numpy as np
 
-version = "1.0.1"
+version = "1.0.2"
 
 # converts count data to fpkm and tpm values
 # remove anyheaders ...

--- a/scripts/get_tpm_fpkm.py
+++ b/scripts/get_tpm_fpkm.py
@@ -6,7 +6,7 @@ import argparse
 import pandas as pd
 import numpy as np
 
-version = "1.0.2"
+version = "0.1.2"
 
 # converts count data to fpkm and tpm values
 # remove anyheaders ...

--- a/scripts/gtftools.py
+++ b/scripts/gtftools.py
@@ -5,6 +5,8 @@ import argparse
 import sys
 import tempfile
 
+version = "0.1.2"
+
 ###############
 # sb43 modified to suit casm need and output additional columns : boiotype, gnene name and chromosome
 # Hong-Dong Li, GTFtools: a Python package for analyzing various modes of gene models, bioRxiv, 263517, doi: https://doi.org/10.1101/263517
@@ -733,7 +735,7 @@ parser.add_argument('-s','--isoform',metavar='isoform',help="file name for isofo
 parser.add_argument('-g','--gene',metavar='gene',help="file name for gene bed data.")
 parser.add_argument('-t','--TSS',metavar='TSS',help="file name for a region centering at transcription start site (TSS). It is calculated as (TSS-w,TSS+w) where w is a user-specified distance, say 2000bp.")
 parser.add_argument('-w','--window',metavar='window_size',help="the value of w in calculating TSS regions as described in '-t'. Default: 2000")
-parser.add_argument('-v','--version',action='version',version="GTFtools version:0.6.5-CASM-Revised")
+parser.add_argument('-v','--version',action='version',version="GTFtools version: %s" % version)
 args = parser.parse_args()   # parse command-line arguments
 
 

--- a/scripts/merge_samples.py
+++ b/scripts/merge_samples.py
@@ -5,7 +5,7 @@ import sys
 import argparse
 import pandas as pd
 
-version = "1.0.1"
+version = "0.1.2"
 
 # converts count data to fpkm and tpm values
 # needs some mofifications before running ....

--- a/test/test_in_docker.sh
+++ b/test/test_in_docker.sh
@@ -4,8 +4,8 @@ set -xe
 
 gtftools.py -l test.len Data/test.gtf && diff -q test.len Data/test.len
 
-get_tpm_fpkm.py -c Data/test.count -g test.len && diff -q <(grep -v '#' test_count_fpkm_tpm.tsv) <(grep -v '#' Data/test_count_fpkm_tpm.tsv)
-get_tpm_fpkm.py -c Data/test2.count -g test.len && diff -q <(grep -v '#' test2_count_fpkm_tpm.tsv) <(grep -v '#' Data/test2_count_fpkm_tpm.tsv)
+get_tpm_fpkm.py -c Data/test.count -g test.len && gunzip test_count_fpkm_tpm.tsv.gz && diff -q <(grep -v '#' test_count_fpkm_tpm.tsv) <(grep -v '#' Data/test_count_fpkm_tpm.tsv)
+get_tpm_fpkm.py -c Data/test2.count -g test.len && gunzip test2_count_fpkm_tpm.tsv.gz && diff -q <(grep -v '#' test2_count_fpkm_tpm.tsv) <(grep -v '#' Data/test2_count_fpkm_tpm.tsv)
 
 merge_samples.py -g test.len -merge_ext _count_fpkm_tpm.tsv
 diff -q merged_count.tsv Data/merged_count.tsv


### PR DESCRIPTION
* cleaned output header of `get_tmp_fpkm.py`; It now produces compressed output by default, and has a `--no-compression` option to disable it.