### PR TITLE
WIP: DO NOT MERGE - adding a fix to gtftools.py to cope with ERCC genes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # CHANGES
 
+## 0.1.54
+
+* `gtftools.py` adding support for non standard ensembl lines, mainly for ERCC92 useage
+  * Giving gene_biotype a default of `unknown`if absent
+
 ## 0.1.4
 
 * missed updating Dockerfile version number in 0.1.3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## 0.1.54
 
-* `gtftools.py` adding support for non standard ensembl lines, mainly for ERCC92 useage
+* `gtftools.py` adding support for non standard ensembl lines, mainly for ERCC92 usage
   * Giving gene_biotype a default of `unknown`if absent
 
 ## 0.1.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 LABEL maintainer="cgphelp@sanger.ac.uk" \
       uk.ac.sanger.cgp="Cancer, Ageing and Somatic Mutation, Wellcome Trust Sanger Institute" \
-      version="0.1.4" \
+      version="0.1.5" \
       description="cgp-convert-counts container"
 
 RUN apt-get -yq update

--- a/scripts/get_tpm_fpkm.py
+++ b/scripts/get_tpm_fpkm.py
@@ -6,7 +6,7 @@ import argparse
 import pandas as pd
 import numpy as np
 
-version = "0.1.4"
+version = "0.1.5"
 
 # converts count data to fpkm and tpm values
 # remove anyheaders ...

--- a/scripts/gtftools.py
+++ b/scripts/gtftools.py
@@ -5,7 +5,7 @@ import argparse
 import sys
 import tempfile
 
-version = "0.1.4"
+version = "0.1.5"
 
 ###############
 # sb43 modified to suit casm need and output additional columns : boiotype, gnene name and chromosome
@@ -293,7 +293,11 @@ def merge_exon(GTFfile_obj,merged_exon_file=''):
 				else:
 					exon[gene]=[iexon]
 					#sb43 done only once for each gene....
-					biotype = line.split('gene_biotype')[1].split('"')[1]
+					if line.find('gene_biotype') >= 0:
+						biotype = line.split('gene_biotype')[1].split('"')[1]
+					else:
+						biotype = 'unknown'
+
 					if line.find('gene_name') >= 0:
 						gene_name = line.split('gene_name')[1].split('"')[1]
 						gene_meta[gene] = [gene_name, biotype, table[0] ]

--- a/scripts/merge_samples.py
+++ b/scripts/merge_samples.py
@@ -5,7 +5,7 @@ import sys
 import argparse
 import pandas as pd
 
-version = "0.1.4"
+version = "0.1.5"
 
 # converts count data to fpkm and tpm values
 # needs some mofifications before running ....


### PR DESCRIPTION
Very simple fix to cope with the ERCC exon annotations. 

If there is no gene_biotype attribute on the exon line it just assigns 'unknown' instead of crashing with an index out of bounds.  On normal Ensembl GTF data it produces identical results. 